### PR TITLE
Reintroduce duplicate captions

### DIFF
--- a/coco_subset_128_images/captions_train2017.json
+++ b/coco_subset_128_images/captions_train2017.json
@@ -1338,9 +1338,49 @@
       "caption": "A man standing next to his guitar case talking on his cell phone."
     },
     {
+      "image_id": 1732,
+      "id": 409535,
+      "caption": "A man talking on a cell phone, standing next to a guitar case."
+    },
+    {
+      "image_id": 1732,
+      "id": 409559,
+      "caption": "A man in black stands next to a guitar case near a white wall."
+    },
+    {
+      "image_id": 1732,
+      "id": 415592,
+      "caption": "a man with a guitar on a cell phone"
+    },
+    {
+      "image_id": 1732,
+      "id": 416870,
+      "caption": "Man on a cellphone by a white wall with a guitar case."
+    },
+    {
       "image_id": 3124,
       "id": 429380,
       "caption": "A leaps straight up into the air with a flying frisbee in front of him."
+    },
+    {
+      "image_id": 3124,
+      "id": 429866,
+      "caption": "The people in the field are playing Frisbee. "
+    },
+    {
+      "image_id": 3124,
+      "id": 430829,
+      "caption": "A group of people who are standing in the grass."
+    },
+    {
+      "image_id": 3124,
+      "id": 432596,
+      "caption": "The man in a white jersey jumps up to catch a Frisbee."
+    },
+    {
+      "image_id": 3124,
+      "id": 434528,
+      "caption": "Young soccer player jumping to catch a frisbee. "
     },
     {
       "image_id": 13473,
@@ -1348,9 +1388,49 @@
       "caption": "The man in the brown suit is holding a coffee mug."
     },
     {
+      "image_id": 13473,
+      "id": 399978,
+      "caption": "The man is covering his face with the mug."
+    },
+    {
+      "image_id": 13473,
+      "id": 401325,
+      "caption": "A young professional man holding a mug to keep himself hidden. "
+    },
+    {
+      "image_id": 13473,
+      "id": 515355,
+      "caption": "a person holds a cup of coffee in front of their face"
+    },
+    {
+      "image_id": 13473,
+      "id": 519975,
+      "caption": "A man holding up a  blue mug in front of a clock."
+    },
+    {
       "image_id": 14276,
       "id": 131793,
       "caption": "A close-up of a zebra looking back behind him."
+    },
+    {
+      "image_id": 14276,
+      "id": 134247,
+      "caption": "A zebra is in front of some dry trees."
+    },
+    {
+      "image_id": 14276,
+      "id": 135861,
+      "caption": "An animal that is looking at something behind it."
+    },
+    {
+      "image_id": 14276,
+      "id": 137850,
+      "caption": "a zebra looking behind while standing on a dirt field next to shrubbery."
+    },
+    {
+      "image_id": 14276,
+      "id": 140052,
+      "caption": "An adult zebra looking behind while standing near bushes."
     },
     {
       "image_id": 14748,
@@ -1358,9 +1438,49 @@
       "caption": "A lady pouring brandy into blue sifters on a table set with white dishes."
     },
     {
+      "image_id": 14748,
+      "id": 484950,
+      "caption": "A woman at a table with a blue glass in her hand. "
+    },
+    {
+      "image_id": 14748,
+      "id": 489174,
+      "caption": "A woman is pouring a drink and the plate holds sugar cubes."
+    },
+    {
+      "image_id": 14748,
+      "id": 490206,
+      "caption": "A woman that is sitting next to a table."
+    },
+    {
+      "image_id": 14748,
+      "id": 824019,
+      "caption": "A woman pouring some drink into a glass at a table."
+    },
+    {
       "image_id": 20809,
       "id": 757881,
       "caption": "this is a dorm room with an orange chair"
+    },
+    {
+      "image_id": 20809,
+      "id": 759733,
+      "caption": "A room with a red chair, refrigerator, and microwave."
+    },
+    {
+      "image_id": 20809,
+      "id": 761455,
+      "caption": "The room is very cluttered and narrow and empty."
+    },
+    {
+      "image_id": 20809,
+      "id": 763624,
+      "caption": "Inside of an apartment building with a fridge and microwave."
+    },
+    {
+      "image_id": 20809,
+      "id": 764611,
+      "caption": "an orange chair some shelves a fridge and a microwave"
     },
     {
       "image_id": 23450,
@@ -1368,9 +1488,49 @@
       "caption": "A man that is standing in front of trays of meat."
     },
     {
+      "image_id": 23450,
+      "id": 751755,
+      "caption": "A man preparing a large amount of chicken."
+    },
+    {
+      "image_id": 23450,
+      "id": 752082,
+      "caption": "A person that is holding food next to trays."
+    },
+    {
+      "image_id": 23450,
+      "id": 755225,
+      "caption": "A man is seasoning meat while working in the kitchen."
+    },
+    {
+      "image_id": 23450,
+      "id": 761022,
+      "caption": "A young male putting raw meat into metal pans covered in plastic wrap."
+    },
+    {
       "image_id": 26172,
       "id": 486137,
       "caption": "a train drives next to a bunch of brush "
+    },
+    {
+      "image_id": 26172,
+      "id": 492266,
+      "caption": "The passenger train drives near a wire fence."
+    },
+    {
+      "image_id": 26172,
+      "id": 493109,
+      "caption": "A train driving by on the train tracks."
+    },
+    {
+      "image_id": 26172,
+      "id": 493799,
+      "caption": "a train going down a track next to some trees "
+    },
+    {
+      "image_id": 26172,
+      "id": 818449,
+      "caption": "A train moves along a quiet railroad track."
     },
     {
       "image_id": 40870,
@@ -1378,9 +1538,49 @@
       "caption": "Two jets tied down at an airport one with number 101 on the nose."
     },
     {
+      "image_id": 40870,
+      "id": 99814,
+      "caption": "Fighter jet on a airstrip with low hanging clouds."
+    },
+    {
+      "image_id": 40870,
+      "id": 103966,
+      "caption": "Several gray jets sitting on a runway by a city."
+    },
+    {
+      "image_id": 40870,
+      "id": 105139,
+      "caption": "Three jets on a runway on the outskirts of a city."
+    },
+    {
+      "image_id": 40870,
+      "id": 112087,
+      "caption": "The jet stands firm with white vibrant clouds in the back."
+    },
+    {
       "image_id": 42516,
       "id": 605206,
       "caption": "a person walking on a city street with an opened umbrella"
+    },
+    {
+      "image_id": 42516,
+      "id": 611743,
+      "caption": "A man walking across a street with an umbrella."
+    },
+    {
+      "image_id": 42516,
+      "id": 611752,
+      "caption": "A man with an umbrella is crossing the street."
+    },
+    {
+      "image_id": 42516,
+      "id": 612328,
+      "caption": "It is out in the open with numerous things in perspective. \n"
+    },
+    {
+      "image_id": 42516,
+      "id": 613579,
+      "caption": "A young person with an umbrella is crossing a busy intersection. "
     },
     {
       "image_id": 46764,
@@ -1388,9 +1588,49 @@
       "caption": "A young man holding a box with a slice of pizza in it"
     },
     {
+      "image_id": 46764,
+      "id": 614524,
+      "caption": "A group of boys eating pizza. One of them is making a sad face"
+    },
+    {
+      "image_id": 46764,
+      "id": 615133,
+      "caption": "Numerous individuals are out and having a fabulous time there. \n"
+    },
+    {
+      "image_id": 46764,
+      "id": 615628,
+      "caption": "a couple of people are eating a pizza"
+    },
+    {
+      "image_id": 46764,
+      "id": 616651,
+      "caption": "Young men sharing pizza at a restaurant. "
+    },
+    {
       "image_id": 48601,
       "id": 640760,
       "caption": "A pair of blue scissors is on a sheet of notebook paper."
+    },
+    {
+      "image_id": 48601,
+      "id": 641738,
+      "caption": "Blue handled scissors with sheet of paper on wooden surface."
+    },
+    {
+      "image_id": 48601,
+      "id": 646169,
+      "caption": "Scissors with word Congratulations resting on lined paper."
+    },
+    {
+      "image_id": 48601,
+      "id": 647138,
+      "caption": "A pair of scissors sitting on a piece of paper."
+    },
+    {
+      "image_id": 48601,
+      "id": 648509,
+      "caption": "A pair of blue handled scissors atop a legal pad."
     },
     {
       "image_id": 50306,
@@ -1398,9 +1638,49 @@
       "caption": "The table is holding, pizza, eating utensils and glasses of orange juice."
     },
     {
+      "image_id": 50306,
+      "id": 417135,
+      "caption": "A table at a restaurant holds two pizzas and orange juice."
+    },
+    {
+      "image_id": 50306,
+      "id": 419829,
+      "caption": "A pizza on a plate is on a table with drinks and utensils."
+    },
+    {
+      "image_id": 50306,
+      "id": 421182,
+      "caption": "Baked pizza displayed on serving dish with beverages on small table."
+    },
+    {
+      "image_id": 50306,
+      "id": 424692,
+      "caption": "A cooked pizza sitting on a pan at the table with a drink, fork and knife. "
+    },
+    {
       "image_id": 52016,
       "id": 539899,
       "caption": "A person standing by a building with a doughnut."
+    },
+    {
+      "image_id": 52016,
+      "id": 540271,
+      "caption": "A WOMAN IS EATING A DOUGHNUT AND SMILING ITH IT IN HAND "
+    },
+    {
+      "image_id": 52016,
+      "id": 543511,
+      "caption": "There is a woman who is holding a donut."
+    },
+    {
+      "image_id": 52016,
+      "id": 549166,
+      "caption": "A woman with a cake and bag on the street"
+    },
+    {
+      "image_id": 52016,
+      "id": 549691,
+      "caption": "A woman eating a doughnut with a smile on her face."
     },
     {
       "image_id": 63309,
@@ -1408,9 +1688,49 @@
       "caption": "A big rock walkway is on a hill beside the ocean."
     },
     {
+      "image_id": 63309,
+      "id": 19474,
+      "caption": "A small road near an ocean cliff side. "
+    },
+    {
+      "image_id": 63309,
+      "id": 25291,
+      "caption": "A road running along side a rocky shore next to the ocean."
+    },
+    {
+      "image_id": 63309,
+      "id": 26116,
+      "caption": "A wall cutting through a large hill by the water."
+    },
+    {
+      "image_id": 63309,
+      "id": 31678,
+      "caption": "A hillside near the ocean with a large wall and possibly a road constructed into the hill."
+    },
+    {
       "image_id": 65716,
       "id": 170659,
       "caption": "An open laptop computer sitting on top of a desk."
+    },
+    {
+      "image_id": 65716,
+      "id": 180253,
+      "caption": "An open laptop with a monitor behind it."
+    },
+    {
+      "image_id": 65716,
+      "id": 182059,
+      "caption": "The laptop is displaying many lines of text."
+    },
+    {
+      "image_id": 65716,
+      "id": 182665,
+      "caption": "a silver laptop on a brown desk and a monitor"
+    },
+    {
+      "image_id": 65716,
+      "id": 188173,
+      "caption": "A computer monitor and a laptop displaying screens of data in an office."
     },
     {
       "image_id": 67414,
@@ -1418,9 +1738,49 @@
       "caption": "A zebra sticking it's head inside of a car door window."
     },
     {
+      "image_id": 67414,
+      "id": 553607,
+      "caption": "a zebra sticking its head into a car window"
+    },
+    {
+      "image_id": 67414,
+      "id": 555725,
+      "caption": "A zebra pokes its head through a car window."
+    },
+    {
+      "image_id": 67414,
+      "id": 560750,
+      "caption": "A zebra's head goes into a car window."
+    },
+    {
+      "image_id": 67414,
+      "id": 563009,
+      "caption": "A couple of zebra standing next to a car."
+    },
+    {
       "image_id": 70197,
       "id": 640323,
       "caption": "The young person is jumping with a skateboard down a flight of steps."
+    },
+    {
+      "image_id": 70197,
+      "id": 642195,
+      "caption": "A young skateboarder performs a trick on the stairway."
+    },
+    {
+      "image_id": 70197,
+      "id": 642858,
+      "caption": "A person riding a skateboard doing tricks on the steps"
+    },
+    {
+      "image_id": 70197,
+      "id": 645657,
+      "caption": "The boy with the skateboard is jumping the steps."
+    },
+    {
+      "image_id": 70197,
+      "id": 648108,
+      "caption": "A person holding a skateboard with one hand and one foot on it, in the air just above a step, outside in dark, paved area by building."
     },
     {
       "image_id": 71828,
@@ -1428,9 +1788,49 @@
       "caption": "two bulls next to a tree and crop"
     },
     {
+      "image_id": 71828,
+      "id": 165552,
+      "caption": "Two horned cattle are tied to a wooden cart."
+    },
+    {
+      "image_id": 71828,
+      "id": 168687,
+      "caption": "A pair of white brahma cattle stand by a wooded cart."
+    },
+    {
+      "image_id": 71828,
+      "id": 168705,
+      "caption": "Two white horned cows standing next to each other near a tree."
+    },
+    {
+      "image_id": 71828,
+      "id": 170091,
+      "caption": "two white oxen are standing by a wood cart "
+    },
+    {
       "image_id": 101753,
       "id": 270948,
       "caption": "a stop sign a person walking and a food shop"
+    },
+    {
+      "image_id": 101753,
+      "id": 271245,
+      "caption": "A stop sign with a sticker on it."
+    },
+    {
+      "image_id": 101753,
+      "id": 272439,
+      "caption": "Advocacy sign posted on a STOP sign in a city. "
+    },
+    {
+      "image_id": 101753,
+      "id": 275127,
+      "caption": "A big sign telling people to stop eating animals next to a building with cars parked outside"
+    },
+    {
+      "image_id": 101753,
+      "id": 278745,
+      "caption": "A stop sign is pictured in the foreground with the Wendy's Restaurant in the background. "
     },
     {
       "image_id": 105389,
@@ -1438,9 +1838,49 @@
       "caption": "A girl holding up different colors of crepe paper."
     },
     {
+      "image_id": 105389,
+      "id": 763424,
+      "caption": "The woman is holding colorful strips of paper ribbon near children. "
+    },
+    {
+      "image_id": 105389,
+      "id": 764636,
+      "caption": "A woman is looking at ribbon for children participating in an art activity."
+    },
+    {
+      "image_id": 105389,
+      "id": 766604,
+      "caption": "Woman with string of paper making art project."
+    },
+    {
+      "image_id": 105389,
+      "id": 769715,
+      "caption": "A groupe of people doing some crafts at a table."
+    },
+    {
       "image_id": 107745,
       "id": 473242,
       "caption": "Many motorcycles are parked as people look on. "
+    },
+    {
+      "image_id": 107745,
+      "id": 475645,
+      "caption": "A large group of motorcycles that are parked."
+    },
+    {
+      "image_id": 107745,
+      "id": 478786,
+      "caption": "A group of people standing around parked motorcycles."
+    },
+    {
+      "image_id": 107745,
+      "id": 483670,
+      "caption": "A motorcycle rally in a parking lot in the city "
+    },
+    {
+      "image_id": 107745,
+      "id": 819646,
+      "caption": "A large gathering of people and their motorcycles in a parking lot. "
     },
     {
       "image_id": 126809,
@@ -1448,9 +1888,49 @@
       "caption": "Spectators and players watching a professional baseball game"
     },
     {
+      "image_id": 126809,
+      "id": 799117,
+      "caption": "A batter on a baseball field preparing for a pitch with catcher and umpire behind."
+    },
+    {
+      "image_id": 126809,
+      "id": 807148,
+      "caption": "A man that is standing in the dirt with a bat."
+    },
+    {
+      "image_id": 126809,
+      "id": 807508,
+      "caption": "A man holding a baseball bat on a field."
+    },
+    {
+      "image_id": 126809,
+      "id": 808162,
+      "caption": "a baseball player is holding up a bat"
+    },
+    {
       "image_id": 129803,
       "id": 330990,
       "caption": "an gray and white horse at the beach"
+    },
+    {
+      "image_id": 129803,
+      "id": 332298,
+      "caption": "An animal eating from the ground near a beach."
+    },
+    {
+      "image_id": 129803,
+      "id": 333138,
+      "caption": "A brown and white horse grazing on lush green grass."
+    },
+    {
+      "image_id": 129803,
+      "id": 334647,
+      "caption": "A horse with its head down eating grass."
+    },
+    {
+      "image_id": 129803,
+      "id": 337332,
+      "caption": "A gray and white horse eating grass on a beach."
     },
     {
       "image_id": 132217,
@@ -1458,9 +1938,49 @@
       "caption": "A woman skiing down a snow covered ski slope"
     },
     {
+      "image_id": 132217,
+      "id": 276735,
+      "caption": "an image of a woman playing on skiis"
+    },
+    {
+      "image_id": 132217,
+      "id": 279396,
+      "caption": "a woman skiing on a flat surface of snow pulling a sled"
+    },
+    {
+      "image_id": 132217,
+      "id": 283407,
+      "caption": "Woman is posing for a picture while skiing."
+    },
+    {
+      "image_id": 132217,
+      "id": 284430,
+      "caption": "A girl on skis pulling a sled with gear on it."
+    },
+    {
       "image_id": 133291,
       "id": 682179,
       "caption": "a couple of guys that are eating some food"
+    },
+    {
+      "image_id": 133291,
+      "id": 684150,
+      "caption": "A couple of men sitting at a table with pizza."
+    },
+    {
+      "image_id": 133291,
+      "id": 686559,
+      "caption": "Two men hold up glasses of bear above two pizzas."
+    },
+    {
+      "image_id": 133291,
+      "id": 687525,
+      "caption": "Two men eating pizza raise their glasses in a toast"
+    },
+    {
+      "image_id": 133291,
+      "id": 688512,
+      "caption": "Two men holding up their beers, on the side of a street."
     },
     {
       "image_id": 134169,
@@ -1468,9 +1988,49 @@
       "caption": "A young girl and suited man are in a school atmosphere."
     },
     {
+      "image_id": 134169,
+      "id": 604476,
+      "caption": "The man stands next to a smiling girl's display."
+    },
+    {
+      "image_id": 134169,
+      "id": 606081,
+      "caption": "A man and a girl are looking at papers on a table."
+    },
+    {
+      "image_id": 134169,
+      "id": 611376,
+      "caption": "A man in a suit looks on what appears to be a schoolgirl's project."
+    },
+    {
+      "image_id": 134169,
+      "id": 611430,
+      "caption": "a man and a girl are looking at a piece of paper"
+    },
+    {
       "image_id": 137118,
       "id": 724554,
       "caption": "An empty living room in an apartment with several chairs sitting in the middle of it."
+    },
+    {
+      "image_id": 137118,
+      "id": 725073,
+      "caption": "An apartment that does not have much furniture and a messy kitchen. "
+    },
+    {
+      "image_id": 137118,
+      "id": 726381,
+      "caption": "A house with no furniture and only a few chairs."
+    },
+    {
+      "image_id": 137118,
+      "id": 728646,
+      "caption": "A room with threes chairs, a rug, a shoe and a basket in it. "
+    },
+    {
+      "image_id": 137118,
+      "id": 729114,
+      "caption": "The apartment has some chairs but doesn't appear to be lived in."
     },
     {
       "image_id": 139400,
@@ -1478,9 +2038,49 @@
       "caption": "A very tall clock tower towering over a small city."
     },
     {
+      "image_id": 139400,
+      "id": 554179,
+      "caption": "A tall building with clocks on different areas of the building."
+    },
+    {
+      "image_id": 139400,
+      "id": 554917,
+      "caption": "Church steeple with four visible clocks overlooking a city."
+    },
+    {
+      "image_id": 139400,
+      "id": 557023,
+      "caption": "The tower of the building has a clock displayed. "
+    },
+    {
+      "image_id": 139400,
+      "id": 561226,
+      "caption": "A green top clock tower in a large city"
+    },
+    {
       "image_id": 144027,
       "id": 799557,
       "caption": "a close up of bowls of food with carrots "
+    },
+    {
+      "image_id": 144027,
+      "id": 802359,
+      "caption": "Four bowls of vegetables, pasta, bread and other healthy foods "
+    },
+    {
+      "image_id": 144027,
+      "id": 803874,
+      "caption": "Various types of food separated into multiple bowls"
+    },
+    {
+      "image_id": 144027,
+      "id": 804501,
+      "caption": "There are bowls of food with vegetables and cheese and bread."
+    },
+    {
+      "image_id": 144027,
+      "id": 808713,
+      "caption": "Several bowls of food including bread, cheese, carrots, salad, and noodles."
     },
     {
       "image_id": 150717,
@@ -1488,9 +2088,49 @@
       "caption": "A group of air planes sitting on a runway."
     },
     {
+      "image_id": 150717,
+      "id": 542597,
+      "caption": "A group of planes parked in the airport"
+    },
+    {
+      "image_id": 150717,
+      "id": 549608,
+      "caption": "The airplanes are lined up on the tarmac."
+    },
+    {
+      "image_id": 150717,
+      "id": 551378,
+      "caption": "A group of planes sit on the tarmac at an airport."
+    },
+    {
+      "image_id": 150717,
+      "id": 560573,
+      "caption": "There are multiple airplanes parked next to each other on the runway."
+    },
+    {
       "image_id": 154654,
       "id": 535045,
       "caption": "a flower vase made to look like some guns "
+    },
+    {
+      "image_id": 154654,
+      "id": 536566,
+      "caption": "The vase on the table is holding some flowers. "
+    },
+    {
+      "image_id": 154654,
+      "id": 536881,
+      "caption": "a vase holding flowers that is shaped like guns"
+    },
+    {
+      "image_id": 154654,
+      "id": 538429,
+      "caption": "A white ceramic vase shaped liked pistols with flowers in the barrel"
+    },
+    {
+      "image_id": 154654,
+      "id": 539470,
+      "caption": "Flower vase shaped like three attached, white guns."
     },
     {
       "image_id": 155125,
@@ -1498,9 +2138,49 @@
       "caption": "A man holding a slice of pizza at a wooden table."
     },
     {
+      "image_id": 155125,
+      "id": 92838,
+      "caption": "The young man is preparing to take a bite of his pizza."
+    },
+    {
+      "image_id": 155125,
+      "id": 95223,
+      "caption": "a boy or young man about to eat a large piece of pizza"
+    },
+    {
+      "image_id": 155125,
+      "id": 97560,
+      "caption": "A man sitting at a table holding a large piece of pizza."
+    },
+    {
+      "image_id": 155125,
+      "id": 107574,
+      "caption": "An Asian man prepares to eat a giant piece of pizza."
+    },
+    {
       "image_id": 155299,
       "id": 231901,
       "caption": "A kitchen filled with a large freezer refrigerator and a table with wooden chairs."
+    },
+    {
+      "image_id": 155299,
+      "id": 254824,
+      "caption": "A table, chair and fridge in a room "
+    },
+    {
+      "image_id": 155299,
+      "id": 257650,
+      "caption": "small kitchen table and stainless steel refrigerator in a small dark room"
+    },
+    {
+      "image_id": 155299,
+      "id": 266407,
+      "caption": "A refrigerator is positioned in a dining room making close quarters for a family."
+    },
+    {
+      "image_id": 155299,
+      "id": 266683,
+      "caption": "A dimly lit dining room with a camera flash visible in the mirror."
     },
     {
       "image_id": 158647,
@@ -1508,9 +2188,49 @@
       "caption": "Someone holding up an electronic device in front of a desk."
     },
     {
+      "image_id": 158647,
+      "id": 335122,
+      "caption": "A person is holding a modem for a computer. "
+    },
+    {
+      "image_id": 158647,
+      "id": 336847,
+      "caption": "Someone who is holding a device that hooks up to a computer."
+    },
+    {
+      "image_id": 158647,
+      "id": 338515,
+      "caption": "A woman holding a gaming console above a wooden table."
+    },
+    {
+      "image_id": 158647,
+      "id": 343180,
+      "caption": "A person holding a white electronic device with many ports."
+    },
+    {
       "image_id": 172023,
       "id": 396478,
       "caption": "a close up of a train on a train track wit ha sky background"
+    },
+    {
+      "image_id": 172023,
+      "id": 397558,
+      "caption": "The train is going down the railroad tracks. "
+    },
+    {
+      "image_id": 172023,
+      "id": 398740,
+      "caption": "A blue and yellow train traveling down train tracks."
+    },
+    {
+      "image_id": 172023,
+      "id": 398752,
+      "caption": "The blue and yellow train is pulling cars along the track."
+    },
+    {
+      "image_id": 172023,
+      "id": 401278,
+      "caption": "A yellow and black train is running on railroad tracks."
     },
     {
       "image_id": 177628,
@@ -1518,9 +2238,49 @@
       "caption": "A black terrier in a snowy field with a flock of black-faced sheep."
     },
     {
+      "image_id": 177628,
+      "id": 765246,
+      "caption": "THIS IS A PHOTO OF SHEEP AND A DOG IN THE SNOW"
+    },
+    {
+      "image_id": 177628,
+      "id": 767028,
+      "caption": "A black dog and sheep in a snowy field."
+    },
+    {
+      "image_id": 177628,
+      "id": 767103,
+      "caption": "A herd of sheep standing on top of a snow covered field."
+    },
+    {
+      "image_id": 177628,
+      "id": 769425,
+      "caption": "Sheep standing in the snow and a dog in front."
+    },
+    {
       "image_id": 185002,
       "id": 519597,
       "caption": "A street with traffic lights on it and buildings beside it."
+    },
+    {
+      "image_id": 185002,
+      "id": 520833,
+      "caption": "a street filled with parked cars street lights in the night hours"
+    },
+    {
+      "image_id": 185002,
+      "id": 522423,
+      "caption": "A city at street at night covered in street lights."
+    },
+    {
+      "image_id": 185002,
+      "id": 523800,
+      "caption": "A busy city street lit up at night with traffic lights."
+    },
+    {
+      "image_id": 185002,
+      "id": 524982,
+      "caption": "The bright lights of the city by a street at night."
     },
     {
       "image_id": 188079,
@@ -1528,9 +2288,49 @@
       "caption": "There are many things laying on the ground."
     },
     {
+      "image_id": 188079,
+      "id": 762717,
+      "caption": "a white throwing disk is laying in the grass"
+    },
+    {
+      "image_id": 188079,
+      "id": 766509,
+      "caption": "A frisbee is on the grass among other clothing articles. "
+    },
+    {
+      "image_id": 188079,
+      "id": 768957,
+      "caption": "A white Frisbee is on the ground near clothes. "
+    },
+    {
+      "image_id": 188079,
+      "id": 770067,
+      "caption": "a bunch of sports items sit in the grass"
+    },
+    {
       "image_id": 191376,
       "id": 811591,
       "caption": "a street light sits on the corner of a street "
+    },
+    {
+      "image_id": 191376,
+      "id": 812680,
+      "caption": "The pedestrians are walking past the red traffic signal. "
+    },
+    {
+      "image_id": 191376,
+      "id": 814063,
+      "caption": "a street that has some cars on it"
+    },
+    {
+      "image_id": 191376,
+      "id": 815969,
+      "caption": "A traffic light handing over a street next to abuilding."
+    },
+    {
+      "image_id": 191376,
+      "id": 816803,
+      "caption": "A street in a city with cars and pedestrian traffic."
     },
     {
       "image_id": 193640,
@@ -1538,9 +2338,49 @@
       "caption": "A little girl holding a white frisbee next to a play ground."
     },
     {
+      "image_id": 193640,
+      "id": 183139,
+      "caption": "a little girl carrying a white plate over to some large blue containers "
+    },
+    {
+      "image_id": 193640,
+      "id": 212383,
+      "caption": "A girl is playing with water near a playground."
+    },
+    {
+      "image_id": 193640,
+      "id": 245764,
+      "caption": "A girl at a park holds a white plate."
+    },
+    {
+      "image_id": 193640,
+      "id": 823058,
+      "caption": "Young girl spilling water into canisters in the park."
+    },
+    {
       "image_id": 195851,
       "id": 317368,
       "caption": "Some people playing basket ball wearing green uniforms."
+    },
+    {
+      "image_id": 195851,
+      "id": 317908,
+      "caption": "A group of men in basketball game with crowd watching."
+    },
+    {
+      "image_id": 195851,
+      "id": 319780,
+      "caption": "A group of men standing around a basketball court."
+    },
+    {
+      "image_id": 195851,
+      "id": 321811,
+      "caption": "Basketball players playing basketball during a basketball game."
+    },
+    {
+      "image_id": 195851,
+      "id": 324469,
+      "caption": "A group of basket ball players in action on the court."
     },
     {
       "image_id": 205512,
@@ -1548,9 +2388,49 @@
       "caption": "The young man on the skateboard is practicing tricks. "
     },
     {
+      "image_id": 205512,
+      "id": 543494,
+      "caption": "There is a skateboarder riding along the ramp.   "
+    },
+    {
+      "image_id": 205512,
+      "id": 543854,
+      "caption": "a guy that is skateboarding on some kind of concrete"
+    },
+    {
+      "image_id": 205512,
+      "id": 545099,
+      "caption": "A person skateboarding on the top of two ramps in a skate-park. "
+    },
+    {
+      "image_id": 205512,
+      "id": 545288,
+      "caption": "Skateboarder riding his board on the top of a two sided ramp. "
+    },
+    {
       "image_id": 206542,
       "id": 635980,
       "caption": "A black sheep standing next to a cat in an entrance."
+    },
+    {
+      "image_id": 206542,
+      "id": 636349,
+      "caption": "A black goat watches the cat walk out of a doorway."
+    },
+    {
+      "image_id": 206542,
+      "id": 642016,
+      "caption": "A small goat looking at a cat near a barn"
+    },
+    {
+      "image_id": 206542,
+      "id": 642361,
+      "caption": "A goat watching a cat walking out of a barn."
+    },
+    {
+      "image_id": 206542,
+      "id": 642976,
+      "caption": "A gray and white cat near a black goat outside of a barn."
     },
     {
       "image_id": 213103,
@@ -1558,9 +2438,49 @@
       "caption": "A person standing by some flowers and a rail."
     },
     {
+      "image_id": 213103,
+      "id": 580619,
+      "caption": "a man is standing near a large field taking a photo"
+    },
+    {
+      "image_id": 213103,
+      "id": 581201,
+      "caption": "A man taking a picture of a scene."
+    },
+    {
+      "image_id": 213103,
+      "id": 581765,
+      "caption": "A man that has green shirt looking over a rail."
+    },
+    {
+      "image_id": 213103,
+      "id": 582074,
+      "caption": "A man in a green shirt taking a picture."
+    },
+    {
       "image_id": 214106,
       "id": 732567,
       "caption": "A white truck parked on the side of a road."
+    },
+    {
+      "image_id": 214106,
+      "id": 733182,
+      "caption": "a a truck parked on the side of a road near many trees "
+    },
+    {
+      "image_id": 214106,
+      "id": 733941,
+      "caption": "A repair truck is parked on the side of a grassy shoulder."
+    },
+    {
+      "image_id": 214106,
+      "id": 733992,
+      "caption": "A fire truck is parked on the shoulder of a road in the country."
+    },
+    {
+      "image_id": 214106,
+      "id": 736434,
+      "caption": "Road construction truck pulled on side of the road."
     },
     {
       "image_id": 217154,
@@ -1568,9 +2488,49 @@
       "caption": "A woman standing at a bar preparing drink mix."
     },
     {
+      "image_id": 217154,
+      "id": 269158,
+      "caption": "a lady mixes some things in a blender as people look on"
+    },
+    {
+      "image_id": 217154,
+      "id": 269833,
+      "caption": "People sitting around a table as someone puts stuff in a blender."
+    },
+    {
+      "image_id": 217154,
+      "id": 272047,
+      "caption": "A woman putting things into a blender at a counter."
+    },
+    {
+      "image_id": 217154,
+      "id": 275953,
+      "caption": "PEOPLE SITTING AROUND A TABLE AND ONE IS USING A BLENDER"
+    },
+    {
       "image_id": 217397,
       "id": 662616,
       "caption": "The man uses his cell phone near a plate of food."
+    },
+    {
+      "image_id": 217397,
+      "id": 663960,
+      "caption": "a man that is taking a picture of food"
+    },
+    {
+      "image_id": 217397,
+      "id": 670941,
+      "caption": "A man taking a photo of his plate of food."
+    },
+    {
+      "image_id": 217397,
+      "id": 675765,
+      "caption": "Man at table taking photo of plated food on table."
+    },
+    {
+      "image_id": 217397,
+      "id": 680487,
+      "caption": "a man sitting back from his plate of food to take a picture of his meal with his phone"
     },
     {
       "image_id": 226748,
@@ -1578,9 +2538,49 @@
       "caption": "Two people are playing Frisbee while another lady looks on. "
     },
     {
+      "image_id": 226748,
+      "id": 442980,
+      "caption": "A group of people on a field with a Frisbee."
+    },
+    {
+      "image_id": 226748,
+      "id": 442989,
+      "caption": "Two adults running and one adult jumping holding frisbee on a grass and dirt field with a netted soccer goal and trees."
+    },
+    {
+      "image_id": 226748,
+      "id": 445965,
+      "caption": "A man catching a frizzbee  for a game."
+    },
+    {
+      "image_id": 226748,
+      "id": 446697,
+      "caption": "A person is leaping up to catch a Frisbee."
+    },
+    {
       "image_id": 227456,
       "id": 784392,
       "caption": "a bunch of people with a really big umbrella"
+    },
+    {
+      "image_id": 227456,
+      "id": 787230,
+      "caption": "a man under an umbrella stands at a food stand"
+    },
+    {
+      "image_id": 227456,
+      "id": 789663,
+      "caption": "There is an old time truck that appears to be serving food."
+    },
+    {
+      "image_id": 227456,
+      "id": 791112,
+      "caption": "A food service cart serves people out of a converted antique car."
+    },
+    {
+      "image_id": 227456,
+      "id": 793950,
+      "caption": "A person serving food on the back of a antique truck."
     },
     {
       "image_id": 250350,
@@ -1588,9 +2588,49 @@
       "caption": "Two wine glasses sit next to a vase."
     },
     {
+      "image_id": 250350,
+      "id": 615846,
+      "caption": "Two wines glasses sitting on a table and a woman "
+    },
+    {
+      "image_id": 250350,
+      "id": 616524,
+      "caption": "A view of a woman through a wine glass. "
+    },
+    {
+      "image_id": 250350,
+      "id": 617619,
+      "caption": "two champagne glasses sitting on a table in front of a woman "
+    },
+    {
+      "image_id": 250350,
+      "id": 618627,
+      "caption": "A girl being viewed through a wine glass at a table."
+    },
+    {
       "image_id": 251932,
       "id": 98580,
       "caption": "an air plane flying thru the air with a sky background"
+    },
+    {
+      "image_id": 251932,
+      "id": 102144,
+      "caption": "A red plane flies in the blue sky."
+    },
+    {
+      "image_id": 251932,
+      "id": 108375,
+      "caption": "The red jet is flying high in the air."
+    },
+    {
+      "image_id": 251932,
+      "id": 109671,
+      "caption": "A small red jet airplane in flight against a blue sky."
+    },
+    {
+      "image_id": 251932,
+      "id": 112806,
+      "caption": "A small red jet plane flying in the air."
     },
     {
       "image_id": 262777,
@@ -1598,9 +2638,49 @@
       "caption": "Tall buildings surrounding an alley way with birds flying over it."
     },
     {
+      "image_id": 262777,
+      "id": 188680,
+      "caption": "power lines strung up next to some tall buildings "
+    },
+    {
+      "image_id": 262777,
+      "id": 197845,
+      "caption": "birds flying in the air in between two buildings"
+    },
+    {
+      "image_id": 262777,
+      "id": 203800,
+      "caption": "A view of a power line that has a single bird on it."
+    },
+    {
+      "image_id": 262777,
+      "id": 204697,
+      "caption": "Birds in the sky and on a bar in an alleyway."
+    },
+    {
       "image_id": 265628,
       "id": 479469,
       "caption": "A white toilet filled with urine next to a white wall."
+    },
+    {
+      "image_id": 265628,
+      "id": 486597,
+      "caption": "A toilet bowl with the seat up with yellow water inside. "
+    },
+    {
+      "image_id": 265628,
+      "id": 486945,
+      "caption": "A toilet with the lid up and urine in the bowl."
+    },
+    {
+      "image_id": 265628,
+      "id": 487524,
+      "caption": "A white toilet bowl with the lid up in a bathroom"
+    },
+    {
+      "image_id": 265628,
+      "id": 819794,
+      "caption": "a white toilet with its seat lifted up"
     },
     {
       "image_id": 268777,
@@ -1608,9 +2688,49 @@
       "caption": "A metallic refrigerator in a kitchen next to wooden shelves."
     },
     {
+      "image_id": 268777,
+      "id": 241742,
+      "caption": "A faux rock enclosure houses a small refrigerator."
+    },
+    {
+      "image_id": 268777,
+      "id": 241901,
+      "caption": "A shiny metallic refrigerator concealed within an enclosure."
+    },
+    {
+      "image_id": 268777,
+      "id": 242507,
+      "caption": "A silver fridge sits in an alcove in a kitchen next to wooden shelves."
+    },
+    {
+      "image_id": 268777,
+      "id": 255149,
+      "caption": "a fridge in the corner of a room"
+    },
+    {
       "image_id": 269496,
       "id": 492916,
       "caption": "A cat sitting on a couch wearing a santa hat."
+    },
+    {
+      "image_id": 269496,
+      "id": 494581,
+      "caption": "A black and white cat on a couch wearing a Santa Clause hat. "
+    },
+    {
+      "image_id": 269496,
+      "id": 494719,
+      "caption": "A black and white cat with a Santa Claus hat on a couch."
+    },
+    {
+      "image_id": 269496,
+      "id": 495385,
+      "caption": "The cat is sitting with a Santa Claus hat on."
+    },
+    {
+      "image_id": 269496,
+      "id": 820307,
+      "caption": "a black and white cat with a santa hat"
     },
     {
       "image_id": 269853,
@@ -1618,9 +2738,49 @@
       "caption": "A woman that is on skis in the snow."
     },
     {
+      "image_id": 269853,
+      "id": 770239,
+      "caption": "A woman in a green jacket is cross country."
+    },
+    {
+      "image_id": 269853,
+      "id": 771781,
+      "caption": "A woman skiing down a trail in the snow."
+    },
+    {
+      "image_id": 269853,
+      "id": 774208,
+      "caption": "a person on skis rides through the snow "
+    },
+    {
+      "image_id": 269853,
+      "id": 777196,
+      "caption": "A woman cross-country skiing toward a row of trees on a trail."
+    },
+    {
       "image_id": 269973,
       "id": 485126,
       "caption": "A building with a clock on the front of it. "
+    },
+    {
+      "image_id": 269973,
+      "id": 485864,
+      "caption": "An old historic tower sits back from the street."
+    },
+    {
+      "image_id": 269973,
+      "id": 489362,
+      "caption": "A green grass yard with a walkway and dark colored building at the end of the walkway."
+    },
+    {
+      "image_id": 269973,
+      "id": 489836,
+      "caption": "The cement walkway is in front of a stone tower."
+    },
+    {
+      "image_id": 269973,
+      "id": 492140,
+      "caption": "a well trimmed grass and a tall house besides"
     },
     {
       "image_id": 274663,
@@ -1628,9 +2788,49 @@
       "caption": "Train passing along the outskirts of a city area. "
     },
     {
+      "image_id": 274663,
+      "id": 431873,
+      "caption": "a train going down the rail road tracks"
+    },
+    {
+      "image_id": 274663,
+      "id": 436709,
+      "caption": "A train traveling down train tracks near a field."
+    },
+    {
+      "image_id": 274663,
+      "id": 437657,
+      "caption": "A distant shot of a train traveling down the tracks. "
+    },
+    {
+      "image_id": 274663,
+      "id": 439763,
+      "caption": "A white and blue train on tracks next to buildings."
+    },
+    {
       "image_id": 278639,
       "id": 109540,
       "caption": "A green and white quilt on an old metal bed."
+    },
+    {
+      "image_id": 278639,
+      "id": 111787,
+      "caption": "Old iron beds and a mattress in an abandoned bedroom "
+    },
+    {
+      "image_id": 278639,
+      "id": 114163,
+      "caption": "An antique metal bed with a floral mattress sits in a room with peeling wall paper. "
+    },
+    {
+      "image_id": 278639,
+      "id": 114784,
+      "caption": "A picture of a bed that is in a room."
+    },
+    {
+      "image_id": 278639,
+      "id": 115834,
+      "caption": "There is a bed with a mattress on it and a bed with just springs on it "
     },
     {
       "image_id": 283666,
@@ -1638,9 +2838,49 @@
       "caption": "A couple of individuals are getting to know each one in turn in love. \n"
     },
     {
+      "image_id": 283666,
+      "id": 611699,
+      "caption": "two jockeys riding two horses in the sand"
+    },
+    {
+      "image_id": 283666,
+      "id": 613040,
+      "caption": "Two jockeys race their horses down the track."
+    },
+    {
+      "image_id": 283666,
+      "id": 614009,
+      "caption": "Two horses with jockeys racing along a beach."
+    },
+    {
+      "image_id": 283666,
+      "id": 616673,
+      "caption": "Two jockeys on horses on a track outside."
+    },
+    {
       "image_id": 292905,
       "id": 411957,
       "caption": "A man and a woman hold a large tray of doughnuts."
+    },
+    {
+      "image_id": 292905,
+      "id": 413523,
+      "caption": "A man and a woman holding a rack of doughnuts."
+    },
+    {
+      "image_id": 292905,
+      "id": 413925,
+      "caption": "A man and woman holding a tray of donuts."
+    },
+    {
+      "image_id": 292905,
+      "id": 415920,
+      "caption": "Man and woman holding a rack full of donuts. "
+    },
+    {
+      "image_id": 292905,
+      "id": 416607,
+      "caption": "Two people holding up a large tray of doughnuts"
     },
     {
       "image_id": 306305,
@@ -1648,9 +2888,49 @@
       "caption": "Two women standing in a store in front of various liquor"
     },
     {
+      "image_id": 306305,
+      "id": 328741,
+      "caption": "Many bottles of wine inside of a building."
+    },
+    {
+      "image_id": 306305,
+      "id": 332467,
+      "caption": "Two women stand at a store in front of a cooler containing various alcoholic beverages"
+    },
+    {
+      "image_id": 306305,
+      "id": 335515,
+      "caption": "Two women are standing near refrigerators full of wine in a store."
+    },
+    {
+      "image_id": 306305,
+      "id": 340354,
+      "caption": "A woman in checkered jacket standing by a fridge of alcohol."
+    },
+    {
       "image_id": 313789,
       "id": 16493,
       "caption": "Many calendars and bunches of bananas hanging on a wall."
+    },
+    {
+      "image_id": 313789,
+      "id": 16739,
+      "caption": "Clusters of bananas and pictures hanging on a wall."
+    },
+    {
+      "image_id": 313789,
+      "id": 22124,
+      "caption": "A large group of bananas hanging in front of posters"
+    },
+    {
+      "image_id": 313789,
+      "id": 22160,
+      "caption": "Bunches of bananas hung on display at a  market."
+    },
+    {
+      "image_id": 313789,
+      "id": 23333,
+      "caption": "Bunches of bananas stacked on top of magazines. "
     },
     {
       "image_id": 325410,
@@ -1658,9 +2938,49 @@
       "caption": "A big bunch of bananas will be growing were the bud is."
     },
     {
+      "image_id": 325410,
+      "id": 474152,
+      "caption": "A close shot of a banana tree. "
+    },
+    {
+      "image_id": 325410,
+      "id": 477263,
+      "caption": "a plant with an elaborate budding flower attached to it"
+    },
+    {
+      "image_id": 325410,
+      "id": 479930,
+      "caption": "A large bunch of still green bananas still hang from a tree"
+    },
+    {
+      "image_id": 325410,
+      "id": 824619,
+      "caption": "A purple banana sprout hanging from a tree."
+    },
+    {
       "image_id": 327233,
       "id": 226800,
       "caption": "A couple getting married on a sandy beach."
+    },
+    {
+      "image_id": 327233,
+      "id": 259830,
+      "caption": "A man and woman getting married on the beach."
+    },
+    {
+      "image_id": 327233,
+      "id": 262965,
+      "caption": "Young couple exchanging vows on beach while others watch."
+    },
+    {
+      "image_id": 327233,
+      "id": 265386,
+      "caption": "A happy couple gets married on the beautiful beach."
+    },
+    {
+      "image_id": 327233,
+      "id": 269199,
+      "caption": "A couple having a wedding ceremony at the beach."
     },
     {
       "image_id": 327572,
@@ -1668,9 +2988,49 @@
       "caption": "A parked motorcycle next to a crowd of people."
     },
     {
+      "image_id": 327572,
+      "id": 208269,
+      "caption": "A nice motorcycle on a show room floor"
+    },
+    {
+      "image_id": 327572,
+      "id": 211785,
+      "caption": "People are looking at some motorcycles on display."
+    },
+    {
+      "image_id": 327572,
+      "id": 214263,
+      "caption": "A Harley Davidson motorcycle is on display and people are milling about."
+    },
+    {
+      "image_id": 327572,
+      "id": 219402,
+      "caption": "A motorcycle on display in a room with a lot of people."
+    },
+    {
       "image_id": 328847,
       "id": 269006,
       "caption": "a pot full of brocolli and cauliflower is cooking "
+    },
+    {
+      "image_id": 328847,
+      "id": 272360,
+      "caption": "A pot of broccoli and cauliflower sitting on a stove top with a mixing spoon in it."
+    },
+    {
+      "image_id": 328847,
+      "id": 273389,
+      "caption": "A pot of boiling broccoli and cauliflower on a stove"
+    },
+    {
+      "image_id": 328847,
+      "id": 275837,
+      "caption": "A plate of food being prepared on an oven"
+    },
+    {
+      "image_id": 328847,
+      "id": 277301,
+      "caption": "A pot of food with broccoli and cauliflower in it."
     },
     {
       "image_id": 335844,
@@ -1678,9 +3038,49 @@
       "caption": "The portable oven has a small pizza cooking in it."
     },
     {
+      "image_id": 335844,
+      "id": 638742,
+      "caption": "a toaster oven that has a pizza in it"
+    },
+    {
+      "image_id": 335844,
+      "id": 640518,
+      "caption": "A toaster oven with an item baking inside of it."
+    },
+    {
+      "image_id": 335844,
+      "id": 642885,
+      "caption": "A toaster oven on a counter with food inside."
+    },
+    {
+      "image_id": 335844,
+      "id": 643779,
+      "caption": "a microwave oven with some food inside of it "
+    },
+    {
       "image_id": 337552,
       "id": 522476,
       "caption": "A man and girl carrying surfboards down a sidewalk in front of a metro bus."
+    },
+    {
+      "image_id": 337552,
+      "id": 522914,
+      "caption": "Two people walk across the street with surf boards in hand. "
+    },
+    {
+      "image_id": 337552,
+      "id": 524990,
+      "caption": "A couple of people walking across a street holding surfboards."
+    },
+    {
+      "image_id": 337552,
+      "id": 526574,
+      "caption": "a couple of surfers are walking across the street together"
+    },
+    {
+      "image_id": 337552,
+      "id": 531440,
+      "caption": "A person walking in the street while holding two surfboards under his arms and a bus in the background."
     },
     {
       "image_id": 350640,
@@ -1688,9 +3088,49 @@
       "caption": "A lap top screen that reads \"keep calm and carry on.\""
     },
     {
+      "image_id": 350640,
+      "id": 313983,
+      "caption": "Open laptops sit on a white table as two men in dress clothes sit at the table."
+    },
+    {
+      "image_id": 350640,
+      "id": 314547,
+      "caption": "People are sitting around a table with their computers."
+    },
+    {
+      "image_id": 350640,
+      "id": 314580,
+      "caption": "People using laptop computers in an office setting"
+    },
+    {
+      "image_id": 350640,
+      "id": 317670,
+      "caption": "A woman sitting at a table using a laptop computer."
+    },
+    {
       "image_id": 352426,
       "id": 458031,
       "caption": "The kite is aloft, like a giant  sea bird flying high in the evening sky."
+    },
+    {
+      "image_id": 352426,
+      "id": 458571,
+      "caption": "there is a kite being flown at sun down"
+    },
+    {
+      "image_id": 352426,
+      "id": 465678,
+      "caption": "A parachute is flying through the evening sky"
+    },
+    {
+      "image_id": 352426,
+      "id": 466170,
+      "caption": "A parasailer soaring over a slope as the sun sets."
+    },
+    {
+      "image_id": 352426,
+      "id": 821622,
+      "caption": "Kite flying over varied terrain on a mostly cloudy day."
     },
     {
       "image_id": 353989,
@@ -1698,9 +3138,49 @@
       "caption": "A man falls down while skating on a slope"
     },
     {
+      "image_id": 353989,
+      "id": 260922,
+      "caption": "A man falls off his skateboard and hit his head."
+    },
+    {
+      "image_id": 353989,
+      "id": 261792,
+      "caption": "A man lays on the ground while a skateboard is in the air above the ground."
+    },
+    {
+      "image_id": 353989,
+      "id": 264000,
+      "caption": "A skateboarder is separated from his board with feet in the air."
+    },
+    {
+      "image_id": 353989,
+      "id": 264963,
+      "caption": "A person on a skateboard on the ground of a park."
+    },
+    {
       "image_id": 356145,
       "id": 99364,
       "caption": "two people with a motorcycle and trailer parked by a waterfall."
+    },
+    {
+      "image_id": 356145,
+      "id": 102850,
+      "caption": "A guy stands next to a guy riding a motorcycle. "
+    },
+    {
+      "image_id": 356145,
+      "id": 105937,
+      "caption": "a motorcycle with a luggage holder in the back parked next to a waterfall"
+    },
+    {
+      "image_id": 356145,
+      "id": 109105,
+      "caption": "A pair of motorcycle riders stop to admire a waterfall."
+    },
+    {
+      "image_id": 356145,
+      "id": 109915,
+      "caption": "Two motorcyclists near a purple motorcycle towing a trailer."
     },
     {
       "image_id": 359405,
@@ -1708,9 +3188,49 @@
       "caption": "A mans urinal with with a person standing you can only see his shoes, with a waste basket in the room."
     },
     {
+      "image_id": 359405,
+      "id": 807720,
+      "caption": "An in floor urinal in a bathroom stall."
+    },
+    {
+      "image_id": 359405,
+      "id": 809472,
+      "caption": "a floor toilet some legs a trash can and white tiles"
+    },
+    {
+      "image_id": 359405,
+      "id": 811707,
+      "caption": "a tiles bathroom with a urinal and trash can inside of it "
+    },
+    {
+      "image_id": 359405,
+      "id": 812781,
+      "caption": "Some standing next to a urinal that is installed in the floor."
+    },
+    {
       "image_id": 361246,
       "id": 691658,
       "caption": "A set of train tracks traveling past a ball building."
+    },
+    {
+      "image_id": 361246,
+      "id": 691820,
+      "caption": "Urban city near water port with commuter train on rail junction."
+    },
+    {
+      "image_id": 361246,
+      "id": 691907,
+      "caption": "A train rides down the tracks next to a building."
+    },
+    {
+      "image_id": 361246,
+      "id": 695360,
+      "caption": "The railroad is designed to take many twists and turns."
+    },
+    {
+      "image_id": 361246,
+      "id": 697367,
+      "caption": "A train is coming along near some unusual looking tracks."
     },
     {
       "image_id": 362796,
@@ -1718,9 +3238,49 @@
       "caption": "A large tall tower with a clock on top."
     },
     {
+      "image_id": 362796,
+      "id": 567695,
+      "caption": "Big Ben sits on a cloudy fall day in London"
+    },
+    {
+      "image_id": 362796,
+      "id": 571886,
+      "caption": "A tower that has a clock on the side of it."
+    },
+    {
+      "image_id": 362796,
+      "id": 571925,
+      "caption": "The tower of the building has a clock displayed."
+    },
+    {
+      "image_id": 362796,
+      "id": 573707,
+      "caption": "An old clock tower on a cloudy day "
+    },
+    {
       "image_id": 364082,
       "id": 639633,
       "caption": "A woman walking down the street with an orange suitcase"
+    },
+    {
+      "image_id": 364082,
+      "id": 640368,
+      "caption": "A person on a street with a suitcase."
+    },
+    {
+      "image_id": 364082,
+      "id": 643551,
+      "caption": "A woman is walking carrying a rolling luggage case."
+    },
+    {
+      "image_id": 364082,
+      "id": 644262,
+      "caption": "A woman with orange luggage walking down the road,"
+    },
+    {
+      "image_id": 364082,
+      "id": 645696,
+      "caption": "The woman on the sidewalk has an orange suitcase."
     },
     {
       "image_id": 373381,
@@ -1728,9 +3288,49 @@
       "caption": "A bed in a bedroom under a window covered with curtains."
     },
     {
+      "image_id": 373381,
+      "id": 237877,
+      "caption": "A interior room with a bed, desk, and other furniture"
+    },
+    {
+      "image_id": 373381,
+      "id": 238810,
+      "caption": "A bed with a purple headboard sits in a dimly lit bedroom."
+    },
+    {
+      "image_id": 373381,
+      "id": 241618,
+      "caption": "A bed with a mirror behind it and clothes on the floor."
+    },
+    {
+      "image_id": 373381,
+      "id": 243085,
+      "caption": "Double bed in medium sized blue carpeted room."
+    },
+    {
       "image_id": 377080,
       "id": 530084,
       "caption": "a cabin cruiser going down the canal toward a bridge"
+    },
+    {
+      "image_id": 377080,
+      "id": 534674,
+      "caption": "A boat is floating on water and about to go under a bridge."
+    },
+    {
+      "image_id": 377080,
+      "id": 536069,
+      "caption": "A small boat is going down a water channel."
+    },
+    {
+      "image_id": 377080,
+      "id": 536243,
+      "caption": "A boat in the water with people on it about to go under a bridge near a city. "
+    },
+    {
+      "image_id": 377080,
+      "id": 540545,
+      "caption": "The boat is sailing in the water by the bridge."
     },
     {
       "image_id": 378137,
@@ -1738,9 +3338,49 @@
       "caption": "some people are swimming in a large pool"
     },
     {
+      "image_id": 378137,
+      "id": 577744,
+      "caption": "Men in long shirt and pants are laying in a pool."
+    },
+    {
+      "image_id": 378137,
+      "id": 583465,
+      "caption": "People floating on their backs in the swimming pool. "
+    },
+    {
+      "image_id": 378137,
+      "id": 590647,
+      "caption": "Their is a group of people wearing all balk swimming together"
+    },
+    {
+      "image_id": 378137,
+      "id": 591862,
+      "caption": "A group of men dressed in black float in a pool"
+    },
+    {
       "image_id": 379067,
       "id": 776886,
       "caption": "A kitchen dining area with stools, chairs and table."
+    },
+    {
+      "image_id": 379067,
+      "id": 778677,
+      "caption": "The view of a dining table, counter, and kitchen."
+    },
+    {
+      "image_id": 379067,
+      "id": 779694,
+      "caption": "A living space with white walls shows a dinette set, far right, medium dark wood, a package with a lighting fixture, close to some bar stools, dark wood, under a counter, beneath an opening that shows a kitchen area with cabinets and cooktop.  "
+    },
+    {
+      "image_id": 379067,
+      "id": 779742,
+      "caption": "A brown kitchen table with chairs and brown high bar chairs."
+    },
+    {
+      "image_id": 379067,
+      "id": 779916,
+      "caption": "a kitchen with a table and some chairs "
     },
     {
       "image_id": 384512,
@@ -1748,9 +3388,49 @@
       "caption": "Close-up of green bananas still on the stalk"
     },
     {
+      "image_id": 384512,
+      "id": 346326,
+      "caption": "there are many green bananas with the roots still on them"
+    },
+    {
+      "image_id": 384512,
+      "id": 350673,
+      "caption": "A pile of bunches of unripe bananas sitting on a counter."
+    },
+    {
+      "image_id": 384512,
+      "id": 356766,
+      "caption": "A bunch of bananas still attached to each other"
+    },
+    {
+      "image_id": 384512,
+      "id": 359463,
+      "caption": "I cannot tell if those are plantains or unripe bananas."
+    },
+    {
       "image_id": 385580,
       "id": 372491,
       "caption": "Men on phones standing in white room with lights"
+    },
+    {
+      "image_id": 385580,
+      "id": 372503,
+      "caption": "some people and one male is looking at his cellphone"
+    },
+    {
+      "image_id": 385580,
+      "id": 375020,
+      "caption": "Guy with cap on and cup in hand shows another whats on the phone."
+    },
+    {
+      "image_id": 385580,
+      "id": 379211,
+      "caption": "A pair of people stand and talk and play on a phone."
+    },
+    {
+      "image_id": 385580,
+      "id": 380414,
+      "caption": "A man in a red at is standing next to a man with long hair."
     },
     {
       "image_id": 392666,
@@ -1758,9 +3438,49 @@
       "caption": "A close up of the collapsible chair with two bird figurines."
     },
     {
+      "image_id": 392666,
+      "id": 192832,
+      "caption": "Two ceramic birds are sitting on a folding chair."
+    },
+    {
+      "image_id": 392666,
+      "id": 193909,
+      "caption": "a white chair is sitting outside with two porcelain birds "
+    },
+    {
+      "image_id": 392666,
+      "id": 195589,
+      "caption": "A white folding chair with two small items on top."
+    },
+    {
+      "image_id": 392666,
+      "id": 201376,
+      "caption": "A white chair with two glass birds on top of it."
+    },
+    {
       "image_id": 394659,
       "id": 512641,
       "caption": "A kitchen is displayed, showing wooden cabinets and a blue tiled counter top."
+    },
+    {
+      "image_id": 394659,
+      "id": 586435,
+      "caption": "A stove top sitting next to a metallic kitchen sink."
+    },
+    {
+      "image_id": 394659,
+      "id": 593476,
+      "caption": "A view of a stove that is in a kitchen that has no refrigerator."
+    },
+    {
+      "image_id": 394659,
+      "id": 744637,
+      "caption": "A picture of a kitchen with an open drawer over the stove."
+    },
+    {
+      "image_id": 394659,
+      "id": 745591,
+      "caption": "Wooden cabinets over a black stove top with blue tiles and a sink."
     },
     {
       "image_id": 395365,
@@ -1768,9 +3488,49 @@
       "caption": "A boy is standing against a railing on a skateboard. "
     },
     {
+      "image_id": 395365,
+      "id": 474258,
+      "caption": "A little boy on a skateboard leaning against a rail."
+    },
+    {
+      "image_id": 395365,
+      "id": 477972,
+      "caption": "A young person is waiting patiently on the railing while on their skateboard. "
+    },
+    {
+      "image_id": 395365,
+      "id": 478671,
+      "caption": "A little boy on a skateboard stands by a fence."
+    },
+    {
+      "image_id": 395365,
+      "id": 823910,
+      "caption": "A boy wearing a green shirt and helmet is leaning up against a black fence while standing on a skateboard."
+    },
+    {
       "image_id": 396311,
       "id": 26861,
       "caption": "A notepad lays next to an unmade bed."
+    },
+    {
+      "image_id": 396311,
+      "id": 27365,
+      "caption": "An empty bed next to a night stand covered in a blanket."
+    },
+    {
+      "image_id": 396311,
+      "id": 31778,
+      "caption": "A double bed with black sheets in a dark room."
+    },
+    {
+      "image_id": 396311,
+      "id": 31841,
+      "caption": "A bed covered with black bedding is pictured in dim lighting."
+    },
+    {
+      "image_id": 396311,
+      "id": 31904,
+      "caption": "A dimly lit room with a bed in it"
     },
     {
       "image_id": 398534,
@@ -1778,9 +3538,49 @@
       "caption": "A man playing tennis, with two tennis balls on the ground in front of him. "
     },
     {
+      "image_id": 398534,
+      "id": 781762,
+      "caption": "a tennis player with a ball and a racket "
+    },
+    {
+      "image_id": 398534,
+      "id": 781984,
+      "caption": "Man holding tennis racket on court just delivering hit"
+    },
+    {
+      "image_id": 398534,
+      "id": 782497,
+      "caption": "a person that is playing some tennis on a court"
+    },
+    {
+      "image_id": 398534,
+      "id": 784924,
+      "caption": "A man holds a tennis racket on a tennis court."
+    },
+    {
       "image_id": 404282,
       "id": 84702,
       "caption": "A kite flying in the sky over trees."
+    },
+    {
+      "image_id": 404282,
+      "id": 85878,
+      "caption": "An object floats in the air above some trees"
+    },
+    {
+      "image_id": 404282,
+      "id": 90192,
+      "caption": "Four loose balloons over the top of trees."
+    },
+    {
+      "image_id": 404282,
+      "id": 91470,
+      "caption": "A group of balloons are floating up into the sky."
+    },
+    {
+      "image_id": 404282,
+      "id": 93135,
+      "caption": "A kite is soaring high above the tree line."
     },
     {
       "image_id": 407936,
@@ -1788,9 +3588,49 @@
       "caption": "A brown calf is nursing from a cow."
     },
     {
+      "image_id": 407936,
+      "id": 711432,
+      "caption": "A cow and a baby cow stand in a coral."
+    },
+    {
+      "image_id": 407936,
+      "id": 715140,
+      "caption": "a cow stands inside of a holing area "
+    },
+    {
+      "image_id": 407936,
+      "id": 716133,
+      "caption": "A cow is standing in the ranch at night."
+    },
+    {
+      "image_id": 407936,
+      "id": 717099,
+      "caption": "a little cow drinking some milk from its mom"
+    },
+    {
       "image_id": 410988,
       "id": 11416,
       "caption": "View of a small kitchen in an empty apartment"
+    },
+    {
+      "image_id": 410988,
+      "id": 12478,
+      "caption": "A nearly empty kitchen with only a refrigerator."
+    },
+    {
+      "image_id": 410988,
+      "id": 17701,
+      "caption": "An empty kitchen and living room decorated in shades of white and black."
+    },
+    {
+      "image_id": 410988,
+      "id": 18592,
+      "caption": "A white refrigerator in the kitchen of an empty apartment."
+    },
+    {
+      "image_id": 410988,
+      "id": 22054,
+      "caption": "This is a white refrigerator in a kitchen."
     },
     {
       "image_id": 411666,
@@ -1798,9 +3638,49 @@
       "caption": "Tubes of breast milk in a refrigerator. "
     },
     {
+      "image_id": 411666,
+      "id": 585890,
+      "caption": "A refrigerator filled with bottles of milk and food."
+    },
+    {
+      "image_id": 411666,
+      "id": 587657,
+      "caption": "The inside of a refrigerator stocked with breast milk and other items."
+    },
+    {
+      "image_id": 411666,
+      "id": 588119,
+      "caption": "Refrigerator contents, including beverages containers, and row of sample bottles."
+    },
+    {
+      "image_id": 411666,
+      "id": 588230,
+      "caption": "A refrigerator shelf with multiple containers of a liquid. "
+    },
+    {
       "image_id": 411958,
       "id": 225896,
       "caption": "A train traveling down tracks near a loading platform."
+    },
+    {
+      "image_id": 411958,
+      "id": 253589,
+      "caption": "A passenger train inside of a drab train station."
+    },
+    {
+      "image_id": 411958,
+      "id": 256214,
+      "caption": "A metro train is pulling into the station."
+    },
+    {
+      "image_id": 411958,
+      "id": 256868,
+      "caption": "Two passenger trains sit on their rails in a dimly lit station. "
+    },
+    {
+      "image_id": 411958,
+      "id": 260174,
+      "caption": "A train is in an otherwise empty train station."
     },
     {
       "image_id": 415008,
@@ -1808,9 +3688,49 @@
       "caption": "A living room with tan colored furniture and accessories."
     },
     {
+      "image_id": 415008,
+      "id": 10717,
+      "caption": "A family room with light brown furniture and a red Oriental rug."
+    },
+    {
+      "image_id": 415008,
+      "id": 12196,
+      "caption": "A living room with a couch and coffee table."
+    },
+    {
+      "image_id": 415008,
+      "id": 12730,
+      "caption": "A well furnished living room with brown couches and a glass table."
+    },
+    {
+      "image_id": 415008,
+      "id": 820363,
+      "caption": "Two candles inside glass vases sit atop a glass table in front of a leather couch."
+    },
+    {
       "image_id": 416247,
       "id": 262567,
       "caption": "A man sitting in front of a laptop computer."
+    },
+    {
+      "image_id": 416247,
+      "id": 270310,
+      "caption": "A person working on a laptop in an office."
+    },
+    {
+      "image_id": 416247,
+      "id": 275710,
+      "caption": "A man in an office with a laptop computer."
+    },
+    {
+      "image_id": 416247,
+      "id": 279214,
+      "caption": "a close up of a person sitting operating a laptop"
+    },
+    {
+      "image_id": 416247,
+      "id": 280504,
+      "caption": "A person on a laptop computer with a plant next to them."
     },
     {
       "image_id": 416918,
@@ -1818,9 +3738,49 @@
       "caption": "A closeup view of stir fry food "
     },
     {
+      "image_id": 416918,
+      "id": 574059,
+      "caption": "A food dish that consist of both meats and veggies."
+    },
+    {
+      "image_id": 416918,
+      "id": 574473,
+      "caption": "The salad has many different types of vegetables in it."
+    },
+    {
+      "image_id": 416918,
+      "id": 576105,
+      "caption": "a close up of a plate of food with chopped vegetables"
+    },
+    {
+      "image_id": 416918,
+      "id": 579906,
+      "caption": "Close up of a chopped vegetable salad with dressing"
+    },
+    {
       "image_id": 419173,
       "id": 221726,
       "caption": "A beautiful woman in purple holding a tennis racquet."
+    },
+    {
+      "image_id": 419173,
+      "id": 242117,
+      "caption": "A female tennis player is standing on a tennis court."
+    },
+    {
+      "image_id": 419173,
+      "id": 243824,
+      "caption": "A women in a purple tennis outfit walking onto the court."
+    },
+    {
+      "image_id": 419173,
+      "id": 246737,
+      "caption": "Female tennis player in a purple uniform ready to play."
+    },
+    {
+      "image_id": 419173,
+      "id": 251111,
+      "caption": "there is a female tennis player in purple outfit. "
     },
     {
       "image_id": 438492,
@@ -1828,9 +3788,49 @@
       "caption": "A person standing on top of a snow covered ski slope."
     },
     {
+      "image_id": 438492,
+      "id": 499263,
+      "caption": "A snow skier at the bottom of a mountain. "
+    },
+    {
+      "image_id": 438492,
+      "id": 500589,
+      "caption": "A woman on skis standing on the side of a mountain"
+    },
+    {
+      "image_id": 438492,
+      "id": 501897,
+      "caption": "An individual standing on the mountain and posing for a picture. "
+    },
+    {
+      "image_id": 438492,
+      "id": 504294,
+      "caption": "A woman with ski's that is standing in the snow."
+    },
+    {
       "image_id": 443188,
       "id": 773208,
       "caption": "A roller skater is weaving through orange cones."
+    },
+    {
+      "image_id": 443188,
+      "id": 773643,
+      "caption": "a man is rollerskating down a hill past cones"
+    },
+    {
+      "image_id": 443188,
+      "id": 777480,
+      "caption": "A person on a street rollerskating next to orange cones."
+    },
+    {
+      "image_id": 443188,
+      "id": 778338,
+      "caption": "A young man rides a skateboard between some small orange cones."
+    },
+    {
+      "image_id": 443188,
+      "id": 778974,
+      "caption": "A person skating down a road with orange obstacle cones placed on it."
     },
     {
       "image_id": 447413,
@@ -1838,9 +3838,49 @@
       "caption": "A large brown dog laying under an open umbrella."
     },
     {
+      "image_id": 447413,
+      "id": 165262,
+      "caption": "The dog is relaxing in the shade of the umbrella."
+    },
+    {
+      "image_id": 447413,
+      "id": 165769,
+      "caption": "A dog resting under a parasol on a grassy front lawn."
+    },
+    {
+      "image_id": 447413,
+      "id": 167824,
+      "caption": "A dog lounges in the shade of an umbrella. "
+    },
+    {
+      "image_id": 447413,
+      "id": 169774,
+      "caption": "A dog is laying in a yard under an umbrella."
+    },
+    {
       "image_id": 454818,
       "id": 262144,
       "caption": "A large brown dog laying inside of a car."
+    },
+    {
+      "image_id": 454818,
+      "id": 266878,
+      "caption": "A brown and white dog in the dashboard of a truck."
+    },
+    {
+      "image_id": 454818,
+      "id": 267505,
+      "caption": "A dog sitting in the dash of a vehicle looking out the front window."
+    },
+    {
+      "image_id": 454818,
+      "id": 268231,
+      "caption": "The dog is sitting on the dash of the car."
+    },
+    {
+      "image_id": 454818,
+      "id": 268303,
+      "caption": "A dog is sitting near the front window of a vehicle."
     },
     {
       "image_id": 467685,
@@ -1848,9 +3888,49 @@
       "caption": "A black bear is standing in a field"
     },
     {
+      "image_id": 467685,
+      "id": 550413,
+      "caption": "a bear in teh middle of a grassy field"
+    },
+    {
+      "image_id": 467685,
+      "id": 553140,
+      "caption": "A bear sits in a field with red and green grass. "
+    },
+    {
+      "image_id": 467685,
+      "id": 555783,
+      "caption": "A black bear walking across a lush green field."
+    },
+    {
+      "image_id": 467685,
+      "id": 557064,
+      "caption": "A bear walking in a grassy and flower meadow."
+    },
+    {
       "image_id": 468249,
       "id": 216665,
       "caption": "A woman riding a white surfboard on top of a wave in the ocean."
+    },
+    {
+      "image_id": 468249,
+      "id": 230921,
+      "caption": "Man with life vest surfing on crest of wave."
+    },
+    {
+      "image_id": 468249,
+      "id": 231941,
+      "caption": "Surfer in a wet-suit catches a nice wave."
+    },
+    {
+      "image_id": 468249,
+      "id": 232670,
+      "caption": "A surfer hanging on to a wave on a sunny day."
+    },
+    {
+      "image_id": 468249,
+      "id": 243449,
+      "caption": "A surfer at the peak of a wave, about to fall off his board."
     },
     {
       "image_id": 469281,
@@ -1858,9 +3938,49 @@
       "caption": "The large dog is sleeping on a television remote control."
     },
     {
+      "image_id": 469281,
+      "id": 377679,
+      "caption": "A cute dog lazily sleeps on top of a pile of clothes."
+    },
+    {
+      "image_id": 469281,
+      "id": 379863,
+      "caption": "a close up of a god laying on a remote"
+    },
+    {
+      "image_id": 469281,
+      "id": 380241,
+      "caption": "A black dog laying on a pile of clothes."
+    },
+    {
+      "image_id": 469281,
+      "id": 823503,
+      "caption": "A dog lying on the floor on some clothes and a remote "
+    },
+    {
       "image_id": 477724,
       "id": 443514,
       "caption": "A train on the tracks driving by in the day."
+    },
+    {
+      "image_id": 477724,
+      "id": 445743,
+      "caption": "A train that is sitting on the tracks."
+    },
+    {
+      "image_id": 477724,
+      "id": 454434,
+      "caption": "a train on a train track near trees"
+    },
+    {
+      "image_id": 477724,
+      "id": 454680,
+      "caption": "there is a small train that is going down the train tracks"
+    },
+    {
+      "image_id": 477724,
+      "id": 454818,
+      "caption": "A batter getting ready to swing at the next thrown pitch. "
     },
     {
       "image_id": 478841,
@@ -1868,9 +3988,49 @@
       "caption": "A young female surfer is seen riding a wave"
     },
     {
+      "image_id": 478841,
+      "id": 148366,
+      "caption": "A woman surfing on a wave at the beach."
+    },
+    {
+      "image_id": 478841,
+      "id": 151006,
+      "caption": "A surfer takes a sharp turn on the crest of a wave."
+    },
+    {
+      "image_id": 478841,
+      "id": 155395,
+      "caption": "A young teenage girl practicing skiing on small waves."
+    },
+    {
+      "image_id": 478841,
+      "id": 157450,
+      "caption": "A female surfer weaves around the medium-sized waves."
+    },
+    {
       "image_id": 481222,
       "id": 789816,
       "caption": "A baseball hitter and umpire in a game."
+    },
+    {
+      "image_id": 481222,
+      "id": 791754,
+      "caption": "a view of a batter swinging and the catcher ready to catch the ball in the event of a strike"
+    },
+    {
+      "image_id": 481222,
+      "id": 794301,
+      "caption": "crowd warthing baseball players in motion during a game "
+    },
+    {
+      "image_id": 481222,
+      "id": 795993,
+      "caption": "A baseball player hits a ball as the catcher tries to catch it. "
+    },
+    {
+      "image_id": 481222,
+      "id": 797589,
+      "caption": "A baseball player is starting to run to first base."
     },
     {
       "image_id": 486536,
@@ -1878,9 +4038,49 @@
       "caption": "A couple of cats sitting on top of a chair with a wooden back."
     },
     {
+      "image_id": 486536,
+      "id": 482358,
+      "caption": "a grey and blck cat sitting side by side on a chair"
+    },
+    {
+      "image_id": 486536,
+      "id": 484581,
+      "caption": "Two cats laying on a blanket on a chair."
+    },
+    {
+      "image_id": 486536,
+      "id": 489708,
+      "caption": "Two different color cats sitting beside each other in a chair. "
+    },
+    {
+      "image_id": 486536,
+      "id": 489981,
+      "caption": "A black and a grey cat sit beside each other."
+    },
+    {
       "image_id": 487434,
       "id": 77032,
       "caption": "Two male tennis players, one has on a white hat. They look like they were mid conversation."
+    },
+    {
+      "image_id": 487434,
+      "id": 77515,
+      "caption": "Two tennis players are standing and discussing a strategy."
+    },
+    {
+      "image_id": 487434,
+      "id": 78919,
+      "caption": "Two men dressed in white at a tennis match."
+    },
+    {
+      "image_id": 487434,
+      "id": 79072,
+      "caption": "Two tennis players wearing white t-shirts have dark hair and are holding tennis rackets."
+    },
+    {
+      "image_id": 487434,
+      "id": 80524,
+      "caption": "two men competing in a doubles tennis match"
     },
     {
       "image_id": 494273,
@@ -1888,9 +4088,49 @@
       "caption": "A boy sitting in a chair with a stuffed animal in front of him."
     },
     {
+      "image_id": 494273,
+      "id": 29748,
+      "caption": "A young child sitting in a chair with a teddy bear."
+    },
+    {
+      "image_id": 494273,
+      "id": 31164,
+      "caption": "A black and white photo shows a child with a large stuffed animal."
+    },
+    {
+      "image_id": 494273,
+      "id": 32169,
+      "caption": "An old black and white photo of a boy in a chair holding a stuffed animal."
+    },
+    {
+      "image_id": 494273,
+      "id": 36351,
+      "caption": "Small boy sitting in chair holds a stuffed toy almost same size as him. "
+    },
+    {
       "image_id": 497558,
       "id": 267993,
       "caption": "a woman sitting in a chair reading a magazine "
+    },
+    {
+      "image_id": 497558,
+      "id": 268374,
+      "caption": "An older woman reading the paper in her chair."
+    },
+    {
+      "image_id": 497558,
+      "id": 269667,
+      "caption": "A woman sitting in a plush chair with her feet propped up reading a magazine."
+    },
+    {
+      "image_id": 497558,
+      "id": 272655,
+      "caption": "Woman sitting in a yellow couch in a living room. "
+    },
+    {
+      "image_id": 497558,
+      "id": 276525,
+      "caption": "A woman has her feet up reading a magazine."
     },
     {
       "image_id": 499104,
@@ -1898,9 +4138,49 @@
       "caption": "two polar bears playing with each other "
     },
     {
+      "image_id": 499104,
+      "id": 475095,
+      "caption": "Two polar bears are playing with their mouths open"
+    },
+    {
+      "image_id": 499104,
+      "id": 476313,
+      "caption": "Two Polar bears biting towards each other's face."
+    },
+    {
+      "image_id": 499104,
+      "id": 476793,
+      "caption": "Two polar bears are playing on the ice. "
+    },
+    {
+      "image_id": 499104,
+      "id": 477150,
+      "caption": "Two polar bears putting their faces close to each other. "
+    },
+    {
       "image_id": 500271,
       "id": 541749,
       "caption": "An older lady brushes a parrot's hair with a brush. "
+    },
+    {
+      "image_id": 500271,
+      "id": 542958,
+      "caption": "An old woman brushing a small bird "
+    },
+    {
+      "image_id": 500271,
+      "id": 547692,
+      "caption": "An old woman is brushing a parrot on top of a stand. "
+    },
+    {
+      "image_id": 500271,
+      "id": 547698,
+      "caption": "an older woman is petting a white bird with a toothbrush"
+    },
+    {
+      "image_id": 500271,
+      "id": 548997,
+      "caption": "An old lady brushes a bird with a tooth brush. "
     },
     {
       "image_id": 505447,
@@ -1908,9 +4188,49 @@
       "caption": "A plate that is flying in the air during the day."
     },
     {
+      "image_id": 505447,
+      "id": 363433,
+      "caption": "A white airplane that is flying in the sky."
+    },
+    {
+      "image_id": 505447,
+      "id": 364144,
+      "caption": "A photograph of an air plane about to land."
+    },
+    {
+      "image_id": 505447,
+      "id": 365167,
+      "caption": "Jet, with it's landing gears out, flying in the sky"
+    },
+    {
+      "image_id": 505447,
+      "id": 367777,
+      "caption": "The plain has already taken off and in flight."
+    },
+    {
       "image_id": 524311,
       "id": 44070,
       "caption": "A man holding a Wii remote and laughing."
+    },
+    {
+      "image_id": 524311,
+      "id": 45426,
+      "caption": "a man in a blue walled room playing with a wii mote"
+    },
+    {
+      "image_id": 524311,
+      "id": 46785,
+      "caption": "A man holding a white Wii remote laughs"
+    },
+    {
+      "image_id": 524311,
+      "id": 48099,
+      "caption": "A man laughs to others while playing video games."
+    },
+    {
+      "image_id": 524311,
+      "id": 49221,
+      "caption": "Man laughing heartily with Wii controller in his left hand"
     },
     {
       "image_id": 524559,
@@ -1918,9 +4238,49 @@
       "caption": "A couple of men playing a  game of tennis."
     },
     {
+      "image_id": 524559,
+      "id": 656700,
+      "caption": "Onlookers watching people on a green lawn playing a game."
+    },
+    {
+      "image_id": 524559,
+      "id": 656964,
+      "caption": "A crowd of people are watching a tennis match."
+    },
+    {
+      "image_id": 524559,
+      "id": 657246,
+      "caption": "A tennis match with spectators in the stands."
+    },
+    {
+      "image_id": 524559,
+      "id": 658779,
+      "caption": "Tennis players attempting to hit the ball. "
+    },
+    {
       "image_id": 538210,
       "id": 699524,
       "caption": "A messy computer workstation covered with papers and office supplies."
+    },
+    {
+      "image_id": 538210,
+      "id": 701630,
+      "caption": "A cluttered desk with a desktop computer on it. "
+    },
+    {
+      "image_id": 538210,
+      "id": 703769,
+      "caption": "A computer desk has papers and a computer on it"
+    },
+    {
+      "image_id": 538210,
+      "id": 704336,
+      "caption": "A desk with a monitor, keyboard, mouse, papers and a mug on it. "
+    },
+    {
+      "image_id": 538210,
+      "id": 705563,
+      "caption": "A desk is cluttered with a computer and paperwork. "
     },
     {
       "image_id": 539556,
@@ -1928,9 +4288,49 @@
       "caption": "A giraffe and antelope out in the wild."
     },
     {
+      "image_id": 539556,
+      "id": 60878,
+      "caption": "A gazelle is standing and a giraffe is sitting outside."
+    },
+    {
+      "image_id": 539556,
+      "id": 61262,
+      "caption": "an antelope  with a giraffe in the background"
+    },
+    {
+      "image_id": 539556,
+      "id": 62165,
+      "caption": "Animals on display at a zoo or animal refuge."
+    },
+    {
+      "image_id": 539556,
+      "id": 62708,
+      "caption": "A giraffe and gazelle in a sandy terrain.  "
+    },
+    {
       "image_id": 548979,
       "id": 702902,
       "caption": "A giraffe standing in the middle of a lush green field."
+    },
+    {
+      "image_id": 548979,
+      "id": 706907,
+      "caption": "a giraffe stands in the middle of a grassy field in front of a building and a tree."
+    },
+    {
+      "image_id": 548979,
+      "id": 708242,
+      "caption": "a little giraffe standing around on a sunny day"
+    },
+    {
+      "image_id": 548979,
+      "id": 714044,
+      "caption": "Giraffe standing in open field of green plain, with trees lining pasture."
+    },
+    {
+      "image_id": 548979,
+      "id": 714938,
+      "caption": "A giraffe standing in a grassy field by another animal"
     },
     {
       "image_id": 551908,
@@ -1938,9 +4338,49 @@
       "caption": "A plated filled with a fish, potatoes and broccoli."
     },
     {
+      "image_id": 551908,
+      "id": 62120,
+      "caption": "A dish of fish, broccoli and potatoes with sauce."
+    },
+    {
+      "image_id": 551908,
+      "id": 65351,
+      "caption": "Fish, small potatoes and broccoli are arranged on the plate."
+    },
+    {
+      "image_id": 551908,
+      "id": 65486,
+      "caption": "A plate is adorned with a tiny fish sitting on a bed of broccoli, potatoes and carrots."
+    },
+    {
+      "image_id": 551908,
+      "id": 65732,
+      "caption": "A plate with fish, potatoes, carrots and broccoli."
+    },
+    {
       "image_id": 560153,
       "id": 384441,
       "caption": "A bed with white sheets and pillows and a teddy bear."
+    },
+    {
+      "image_id": 560153,
+      "id": 387420,
+      "caption": "A white teddy bear laying on top of pillows."
+    },
+    {
+      "image_id": 560153,
+      "id": 388029,
+      "caption": "a slept in bed with a teddy bear"
+    },
+    {
+      "image_id": 560153,
+      "id": 389799,
+      "caption": "A STUFF BEAR IS SITTING ON THE BED"
+    },
+    {
+      "image_id": 560153,
+      "id": 390507,
+      "caption": "A very cute teddy bear sitting on a bed."
     },
     {
       "image_id": 565296,
@@ -1948,9 +4388,49 @@
       "caption": "Long counter in center of room surrounded by grocery cases."
     },
     {
+      "image_id": 565296,
+      "id": 105951,
+      "caption": "A kitchen area with a counter and refrigerators."
+    },
+    {
+      "image_id": 565296,
+      "id": 110856,
+      "caption": "An empty grocery area with several trash and recycling containers."
+    },
+    {
+      "image_id": 565296,
+      "id": 115719,
+      "caption": "A long table sits in the middle of the floor.\n"
+    },
+    {
+      "image_id": 565296,
+      "id": 119556,
+      "caption": "A long food preparation counter in a commercial kitchen."
+    },
+    {
       "image_id": 567982,
       "id": 747309,
       "caption": "A cup of coffee and a doughnut with a napkin on a blue plate."
+    },
+    {
+      "image_id": 567982,
+      "id": 748023,
+      "caption": "A cup of coffee an donuts placed on a table."
+    },
+    {
+      "image_id": 567982,
+      "id": 749072,
+      "caption": "Coffee and powdered sugar doughnut on a woven cloth."
+    },
+    {
+      "image_id": 567982,
+      "id": 755439,
+      "caption": "A sugar doughnut with coffee and a spoon for breakfast."
+    },
+    {
+      "image_id": 567982,
+      "id": 760219,
+      "caption": "There is a donut resting near a cup of coffee. "
     },
     {
       "image_id": 572769,
@@ -1958,9 +4438,49 @@
       "caption": "Black and white photograph of people outside a white house."
     },
     {
+      "image_id": 572769,
+      "id": 369164,
+      "caption": "An old picture of a boarding house with horses and carriages out front."
+    },
+    {
+      "image_id": 572769,
+      "id": 375257,
+      "caption": "A building with people gathered outside is shown."
+    },
+    {
+      "image_id": 572769,
+      "id": 375740,
+      "caption": "A vintage picture of the McLean House. "
+    },
+    {
+      "image_id": 572769,
+      "id": 376829,
+      "caption": "An old picture of a building with horse drawn carriages and people near it."
+    },
+    {
       "image_id": 575173,
       "id": 87308,
       "caption": "A large passenger jet flying over a large body of water."
+    },
+    {
+      "image_id": 575173,
+      "id": 96083,
+      "caption": "An airplane is flying close to the lake of water below. "
+    },
+    {
+      "image_id": 575173,
+      "id": 96989,
+      "caption": "An airplane on a runway by a body of water."
+    },
+    {
+      "image_id": 575173,
+      "id": 98264,
+      "caption": "The China Airlines jet taxis down the runway next to a body of water."
+    },
+    {
+      "image_id": 575173,
+      "id": 99806,
+      "caption": "AN AIRPLANE THAT READS CHINA AIRLINES IS COMING INTO LANDING"
     },
     {
       "image_id": 578878,
@@ -1968,9 +4488,49 @@
       "caption": "A man sitting down at a table holding a cell phone."
     },
     {
+      "image_id": 578878,
+      "id": 192927,
+      "caption": "A man at a table is looking at his cell phone."
+    },
+    {
+      "image_id": 578878,
+      "id": 193956,
+      "caption": "A man smiles as he looks at something on his phone. "
+    },
+    {
+      "image_id": 578878,
+      "id": 194331,
+      "caption": "A man looking at a cellphone in a kitchen."
+    },
+    {
+      "image_id": 578878,
+      "id": 202713,
+      "caption": "A man sitting at a table using a smart phone."
+    },
+    {
       "image_id": 579758,
       "id": 438128,
       "caption": "Male professional baseball player winding up to pitch the ball. "
+    },
+    {
+      "image_id": 579758,
+      "id": 441521,
+      "caption": "A baseball player winding up to pitch the ball."
+    },
+    {
+      "image_id": 579758,
+      "id": 446507,
+      "caption": "A professional baseball player about to pitch the ball"
+    },
+    {
+      "image_id": 579758,
+      "id": 447272,
+      "caption": "A ma on a baseball field holding a ball up "
+    },
+    {
+      "image_id": 579758,
+      "id": 447746,
+      "caption": "Adult baseball player preparing to throw ball from infield area."
     }
   ]
 }


### PR DESCRIPTION
# What has changed and why?

Reverts lightly-ai/dataset_examples#7

Next release of LightlyStudio can display multiple captions properly.
